### PR TITLE
Adding support for ELB names with non alpha characters

### DIFF
--- a/le_lambda.py
+++ b/le_lambda.py
@@ -99,6 +99,6 @@ def validate_uuid4(uuid):
 
 
 def validate_elb_log(key):
-    regex = re.compile('^\d+_\w+_\w{2}-\w{4,10}-[12]_\w+_\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}_.*.log$', re.I)
+    regex = re.compile('^\d+_\w+_\w{2}-\w{4,10}-[12]_.*_\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}_.*.log$', re.I)
     match = regex.match(key)
     return bool(match)


### PR DESCRIPTION
This adds support for ELB names that contain ‘-‘ and other characters.
