### PR TITLE
Fixed elb log filename validation so that it works with folder prefixes

### DIFF
--- a/le_lambda.py
+++ b/le_lambda.py
@@ -102,6 +102,6 @@ def validate_uuid(uuid_string):
 
 
 def validate_elb_log(key):
-    regex = re.compile('^\d+_\w+_\w{2}-\w{4,9}-[12]_.*._\d{8}T\d{4}Z_\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}_.*.log$', re.I)
+    regex = re.compile('^(.*/)?\d+_\w+_\w{2}-\w{4,9}-[12]_.*._\d{8}T\d{4}Z_\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}_.*.log$', re.I)
     match = regex.match(key)
     return bool(match)


### PR DESCRIPTION
The function `validate_elb_log()` would only validate the name of an ELB log file if it had no prefix. Generally these files _do_ have a prefix inside a bucket, so this PR extends the regular expression to match any prefix followed by a trailing slash.
