### PR TITLE
Support CloudFront access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Follow the instructions below to send logs stored on AWS S3 to Logentries.
 
 ###### Example use cases:
-* Forwarding AWS ELB logs
-  * (make sure to set ELB to write logs every 5 minutes)
-  * When forwarding ELB logs, the script will format the log lines according to Logentries KVP spec to make them easier to analyze
+* Forwarding AWS ELB and CloudFront logs
+  * (make sure to set ELB/CloudFront to write logs every 5 minutes)
+  * When forwarding these logs, the script will format the log lines according to Logentries KVP spec to make them easier to analyze
 * Forwarding OpenDNS logs
 
 ## Obtain log token(s)


### PR DESCRIPTION
This PR adds support for shipping the [access logs](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html) generated by CloudFront to Logentries.

Like ELB logs, CloudFront logs are stored to S3 periodically. This code identifies CloudFront logs by the log file name structure, and then processes them similar to ELB logs. This depended on the already-merged PR #9 for handling gzipped logs.
